### PR TITLE
Fix set-output GHA deprecation warnings (Software-5354)

### DIFF
--- a/.github/workflows/publish-container-manual.yml
+++ b/.github/workflows/publish-container-manual.yml
@@ -57,7 +57,7 @@ jobs:
         # This causes the tag_list array to be comma-separated below,
         # which is required for build-push-action
         IFS=,
-        echo "::set-output name=taglist::${tag_list[*]}"
+        echo "taglist=${tag_list[*]}" >> $GITHUB_OUPUT
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/publish-container-manual.yml
+++ b/.github/workflows/publish-container-manual.yml
@@ -57,7 +57,7 @@ jobs:
         # This causes the tag_list array to be comma-separated below,
         # which is required for build-push-action
         IFS=,
-        echo "taglist=${tag_list[*]}" >> $GITHUB_OUPUT
+        echo "taglist=${tag_list[*]}" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2.7.0

--- a/.github/workflows/publish-container-manual.yml
+++ b/.github/workflows/publish-container-manual.yml
@@ -14,7 +14,7 @@ jobs:
     if: startsWith(github.repository, 'osg-htc/')
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
         ref: ${{ github.ref }}
@@ -60,17 +60,17 @@ jobs:
         echo "taglist=${tag_list[*]}" >> $GITHUB_OUPUT
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2.7.0
 
     - name: Log in to OSG Harbor
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2.2.0
       with:
         registry: hub.opensciencegrid.org
         username: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
         password: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
 
     - name: Build and push Docker images
-      uses: docker/build-push-action@v2.2.0
+      uses: docker/build-push-action@v4
       with:
         context: .
         push: true

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -59,7 +59,7 @@ jobs:
         # This causes the tag_list array to be comma-separated below,
         # which is required for build-push-action
         IFS=,
-        echo "::set-output name=taglist::${tag_list[*]}"
+        echo "taglist=${tag_list[*]}" >> $GITHUB_OUPUT
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -59,7 +59,7 @@ jobs:
         # This causes the tag_list array to be comma-separated below,
         # which is required for build-push-action
         IFS=,
-        echo "taglist=${tag_list[*]}" >> $GITHUB_OUPUT
+        echo "taglist=${tag_list[*]}" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2.7.0

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -16,7 +16,7 @@ jobs:
     if: startsWith(github.repository, 'osg-htc/')
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
         ref: master                              # Needed or it will checkout the wrong commit
@@ -62,17 +62,17 @@ jobs:
         echo "taglist=${tag_list[*]}" >> $GITHUB_OUPUT
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2.7.0
 
     - name: Log in to OSG Harbor
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2.2.0
       with:
         registry: hub.opensciencegrid.org
         username: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
         password: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
 
     - name: Build and push Docker images
-      uses: docker/build-push-action@v2.2.0
+      uses: docker/build-push-action@v4
       with:
         context: .
         push: true

--- a/.github/workflows/release-documentation-update.yml
+++ b/.github/workflows/release-documentation-update.yml
@@ -43,8 +43,8 @@ jobs:
     - name: Publish a new release
       id: publish-new-release-tag
       run: |
-        echo "::set-output name=tag::$( python3 ./.github/scripts/create-documentation-release.py ${{ secrets.GITHUB_TOKEN }} )"
-
+        echo "tag=$( python3 ./.github/scripts/create-documentation-release.py ${{ secrets.GITHUB_TOKEN }} )" >> $GITHUB_OUPUT
+        
   Call-publish-container:
     if: startsWith(github.repository, 'osg-htc/')
     needs: Publish-New-Release

--- a/.github/workflows/release-documentation-update.yml
+++ b/.github/workflows/release-documentation-update.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Publish a new release
       id: publish-new-release-tag
       run: |
-        echo "tag=$( python3 ./.github/scripts/create-documentation-release.py ${{ secrets.GITHUB_TOKEN }} )" >> $GITHUB_OUPUT
+        echo "tag=$( python3 ./.github/scripts/create-documentation-release.py ${{ secrets.GITHUB_TOKEN }} )" >> $GITHUB_OUTPUT
         
   Call-publish-container:
     if: startsWith(github.repository, 'osg-htc/')

--- a/.github/workflows/release-documentation-update.yml
+++ b/.github/workflows/release-documentation-update.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.repository, 'osg-htc/')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
         fetch-depth: 0
@@ -36,7 +36,7 @@ jobs:
     outputs:
       tag: ${{ steps.publish-new-release-tag.outputs.tag }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 


### PR DESCRIPTION
Fix warnings for publish-container manual.yml, release-documentation-update.yml, and publish-container.yml